### PR TITLE
Enable UWP swap chain for Xbox renderer

### DIFF
--- a/source/ashes/renderer/XBoxRenderer/Core/XBoxSurface.cpp
+++ b/source/ashes/renderer/XBoxRenderer/Core/XBoxSurface.cpp
@@ -193,24 +193,28 @@ namespace ashes::xbox
 			}
 		}
 
-		static std::vector< VkSurfaceFormatKHR > getSurfaceFormats( std::vector< DXGI_MODE_DESC > const & displayModeList )
-		{
-			std::vector< VkSurfaceFormatKHR > result;
-			std::set< VkFormat > uniqueFormats;
+                static std::vector< VkSurfaceFormatKHR > getSurfaceFormats( std::vector< DXGI_MODE_DESC > const & displayModeList )
+                {
+                        std::vector< VkSurfaceFormatKHR > result;
+                        std::set< VkFormat > uniqueFormats;
 
-			for ( auto & displayMode : displayModeList )
-			{
-				auto fmt = getVkFormat( displayMode.Format );
+                        result.push_back( { VK_FORMAT_R8G8B8A8_UNORM, VK_COLORSPACE_SRGB_NONLINEAR_KHR } );
+                        return result;
+                        /*
+                        for ( auto & displayMode : displayModeList )
+                        {
+                                auto fmt = getVkFormat( displayMode.Format );
 
-				if ( uniqueFormats.find( fmt ) == uniqueFormats.end() )
-				{
-					result.push_back( { fmt, VK_COLORSPACE_SRGB_NONLINEAR_KHR } );
-					uniqueFormats.insert( fmt );
-				}
-			}
+                                if ( uniqueFormats.find( fmt ) == uniqueFormats.end() )
+                                {
+                                        result.push_back( { fmt, VK_COLORSPACE_SRGB_NONLINEAR_KHR } );
+                                        uniqueFormats.insert( fmt );
+                                }
+                        }
 
-			return result;
-		}
+                        return result;
+                        */
+                }
 	}
 
 	std::vector< DXGI_MODE_DESC > getDisplayModesList( VkInstance instance

--- a/source/ashes/renderer/XBoxRenderer/Core/XBoxSwapChain.hpp
+++ b/source/ashes/renderer/XBoxRenderer/Core/XBoxSwapChain.hpp
@@ -39,7 +39,7 @@ namespace ashes::xbox
 	private:
 		VkDevice m_device;
 		VkSwapchainCreateInfoKHR m_createInfo;
-		DXGI_SWAP_CHAIN_DESC m_presentDesc;
+                DXGI_SWAP_CHAIN_DESC1 m_presentDesc{};
 		DXGI_MODE_DESC m_displayMode;
 		uint32_t m_currentBuffer{};
 		IDXGISwapChain * m_swapChain{ nullptr };


### PR DESCRIPTION
## Summary
- adjust swap chain descriptor for triple buffering and flip discard
- create UWP swap chain using `CreateSwapChainForCoreWindow`
- fix surface format list to return a single R8G8B8A8_UNORM entry

## Testing
- `cmake -S . -B build` *(fails: could not find requested files and Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_6845adf6adcc832f9b90510ef6eadac1